### PR TITLE
Update API services to 5.0

### DIFF
--- a/Modules/AggregateDiskRelationshipModule.py
+++ b/Modules/AggregateDiskRelationshipModule.py
@@ -27,7 +27,7 @@ warnings.filterwarnings("ignore")
 
 
 def get():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
 
     flag=0
 
@@ -76,7 +76,7 @@ def get():
     return json_response
 
 def post():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="aggregate-disk-relationships"
 
     payload={}
@@ -98,7 +98,7 @@ def post():
     return json_response
 
 def put():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="aggregate-disk-relationships/"
 
     payload={}
@@ -123,7 +123,7 @@ def put():
         return "Provide the object key"
 
 def delete():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="aggregate-disk-relationships/"
 
     if key != None:
@@ -163,6 +163,7 @@ def main():
                 "port" : {"required": True, "type": "str"},
                 "user" : {"required": True, "type": "str"},
                 "password" : {"required": True, "type": "str"},
+                "api_version" : {"required": False, "choices": [ '1.0', '2.0', '3.0', '4.0', '5.0' ], type: "str", "default": '2.0'},
                 "key" : {"required": False, "type": "str"},
                 "aggregate_key" : {"required": False, "type": "str"},
                 "disk_key" : {"required": False, "type": "str"},
@@ -178,6 +179,7 @@ def main():
         global api_port
         global api_user_name
         global api_user_password
+        global api_version
 
         global lun_key
         global nfs_share_key
@@ -186,6 +188,7 @@ def main():
         api_port                = module.params["port"]
         api_user_name           = module.params["user"]
         api_user_password       = module.params["password"]
+        api_version             = module.params["api_version"]
 
         # Properties details
         global key

--- a/Modules/AggregateModule.py
+++ b/Modules/AggregateModule.py
@@ -27,7 +27,7 @@ warnings.filterwarnings("ignore")
 
 
 def get():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
 
     flag=0
 
@@ -244,7 +244,7 @@ def get():
     return json_response
 
 def post():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="aggregates"
 
     payload={}
@@ -322,7 +322,7 @@ def post():
     return json_response
 
 def put():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="aggregates/"
 
     payload={}
@@ -403,7 +403,7 @@ def put():
         return "Provide the object key"
 
 def delete():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="aggregates/"
 
     if key != None:
@@ -443,6 +443,7 @@ def main():
                 "port" : {"required": True, "type": "str"},
                 "user" : {"required": True, "type": "str"},
                 "password" : {"required": True, "type": "str"},
+                "api_version" : {"required": False, "choices": [ '1.0', '2.0', '3.0', '4.0', '5.0' ], type: "str", "default": '2.0'},
                 "key" : {"required": False, "type": "str"},
                 "name" : {"required": False, "type": "str"},
                 "cluster_key" : {"required": False, "type": "str"},
@@ -486,6 +487,7 @@ def main():
         global api_port
         global api_user_name
         global api_user_password
+        global api_version
 
         global lun_key
         global nfs_share_key
@@ -494,6 +496,7 @@ def main():
         api_port                = module.params["port"]
         api_user_name           = module.params["user"]
         api_user_password       = module.params["password"]
+        api_version             = module.params["api_version"]
 
         # Properties details
         global key

--- a/Modules/ApiProxyModule.py
+++ b/Modules/ApiProxyModule.py
@@ -27,7 +27,7 @@ warnings.filterwarnings("ignore")
 
 
 def post():
-    url_path        = "/api/4.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     if(storagevmkey!=None):
         url_path+="storage-vms/"+storagevmkey+"/advanced/jobs/"
     if(clusterkey!=None):
@@ -69,6 +69,7 @@ def main():
                 "port" : {"required": True, "type": "str"},
                 "user" : {"required": True, "type": "str"},
                 "password" : {"required": True, "type": "str"},
+                "api_version" : {"required": False, "choices": [ '3.0', '4.0', '5.0' ], type: "str", "default": '2.0'},
                 "storagevmkey" : {"required": False, "type": "str"},
                 "clusterkey" : {"required": False, "type": "str"},
                 "is_sensitive" : {"required": False, "type": "str"},
@@ -82,6 +83,7 @@ def main():
         global api_port
         global api_user_name
         global api_user_password
+        global api_version
 
         global storagevmkey
         storagevmkey   = module.params["storagevmkey"]
@@ -94,6 +96,7 @@ def main():
         api_port                = module.params["port"]
         api_user_name           = module.params["user"]
         api_user_password       = module.params["password"]
+        api_version             = module.params["api_version"]
 
         # Properties details
         global body

--- a/Modules/ApplicationRecordModule.py
+++ b/Modules/ApplicationRecordModule.py
@@ -27,7 +27,7 @@ warnings.filterwarnings("ignore")
 
 
 def get():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
 
     flag=0
 
@@ -124,7 +124,7 @@ def get():
     return json_response
 
 def post():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="application-records"
 
     payload={}
@@ -162,7 +162,7 @@ def post():
     return json_response
 
 def put():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="application-records/"
 
     payload={}
@@ -203,7 +203,7 @@ def put():
         return "Provide the object key"
 
 def delete():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="application-records/"
 
     if key != None:
@@ -243,6 +243,7 @@ def main():
                 "port" : {"required": True, "type": "str"},
                 "user" : {"required": True, "type": "str"},
                 "password" : {"required": True, "type": "str"},
+                "api_version" : {"required": False, "choices": [ '1.0', '2.0', '3.0', '4.0', '5.0' ], type: "str", "default": '2.0'},
                 "key" : {"required": False, "type": "str"},
                 "record_name" : {"required": False, "type": "str"},
                 "cluster_key" : {"required": False, "type": "str"},
@@ -266,6 +267,7 @@ def main():
         global api_port
         global api_user_name
         global api_user_password
+        global api_version
 
         global lun_key
         global nfs_share_key
@@ -274,6 +276,7 @@ def main():
         api_port                = module.params["port"]
         api_user_name           = module.params["user"]
         api_user_password       = module.params["password"]
+        api_version             = module.params["api_version"]
 
         # Properties details
         global key

--- a/Modules/CIFSShareAclModule.py
+++ b/Modules/CIFSShareAclModule.py
@@ -27,7 +27,7 @@ warnings.filterwarnings("ignore")
 
 
 def get():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
 
     flag=0
 
@@ -87,7 +87,7 @@ def get():
     return json_response
 
 def post():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     if(parentCifsshare#[[key]]#!=None):
         url_path+="cifs-shares/"+parentCifsshare#[[key]]#+"/"
     else:
@@ -115,7 +115,7 @@ def post():
     return json_response
 
 def put():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     if(parentCifsshare#[[key]]#!=None):
         url_path+="cifs-shares/"+parentCifsshare#[[key]]#+"/"
     else:
@@ -146,7 +146,7 @@ def put():
         return "Provide the object key"
 
 def delete():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     if(parentCifsshare#[[key]]#!=None):
         url_path+="cifs-shares/"+parentCifsshare#[[key]]#+"/"
     else:
@@ -190,6 +190,7 @@ def main():
                 "port" : {"required": True, "type": "str"},
                 "user" : {"required": True, "type": "str"},
                 "password" : {"required": True, "type": "str"},
+                "api_version" : {"required": False, "choices": [ '1.0', '2.0', '3.0', '4.0', '5.0' ], type: "str", "default": '2.0'},
                 "parentCifsshare#[[key]]#" : {"required": False, "type": "str"},
                 "key" : {"required": False, "type": "str"},
                 "cifs_share_key" : {"required": False, "type": "str"},
@@ -207,6 +208,7 @@ def main():
         global api_port
         global api_user_name
         global api_user_password
+        global api_version
 
         global parentCifsshare#[[key]]#
         parentCifsshare#[[key]]#   = module.params["parentCifsshare#[[key]]#"]
@@ -217,6 +219,7 @@ def main():
         api_port                = module.params["port"]
         api_user_name           = module.params["user"]
         api_user_password       = module.params["password"]
+        api_version             = module.params["api_version"]
 
         # Properties details
         global key

--- a/Modules/CIFSShareModule.py
+++ b/Modules/CIFSShareModule.py
@@ -27,7 +27,7 @@ warnings.filterwarnings("ignore")
 
 
 def get():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
 
     flag=0
 
@@ -106,7 +106,7 @@ def get():
     return json_response
 
 def post():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="cifs-shares"
 
     payload={}
@@ -138,7 +138,7 @@ def post():
     return json_response
 
 def put():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="cifs-shares/"
 
     payload={}
@@ -173,7 +173,7 @@ def put():
         return "Provide the object key"
 
 def delete():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="cifs-shares/"
 
     if key != None:
@@ -213,6 +213,7 @@ def main():
                 "port" : {"required": True, "type": "str"},
                 "user" : {"required": True, "type": "str"},
                 "password" : {"required": True, "type": "str"},
+                "api_version" : {"required": False, "choices": [ '1.0', '2.0', '3.0', '4.0', '5.0' ], type: "str", "default": '2.0'},
                 "key" : {"required": False, "type": "str"},
                 "name" : {"required": False, "type": "str"},
                 "storage_vm_key" : {"required": False, "type": "str"},
@@ -233,6 +234,7 @@ def main():
         global api_port
         global api_user_name
         global api_user_password
+        global api_version
 
         global lun_key
         global nfs_share_key
@@ -241,6 +243,7 @@ def main():
         api_port                = module.params["port"]
         api_user_name           = module.params["user"]
         api_user_password       = module.params["password"]
+        api_version             = module.params["api_version"]
 
         # Properties details
         global key

--- a/Modules/ClusterModule.py
+++ b/Modules/ClusterModule.py
@@ -27,7 +27,7 @@ warnings.filterwarnings("ignore")
 
 
 def get():
-    url_path        = "/api/2.0/ontap/"
+    url_path = "/api/" + api_version + "/ontap/"
 
     flag=0
 
@@ -172,7 +172,7 @@ def get():
     return json_response
 
 def post():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="clusters"
 
     payload={}
@@ -226,7 +226,7 @@ def post():
     return json_response
 
 def put():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="clusters/"
 
     payload={}
@@ -283,7 +283,7 @@ def put():
         return "Provide the object key"
 
 def delete():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="clusters/"
 
     if key != None:
@@ -323,6 +323,7 @@ def main():
                 "port" : {"required": True, "type": "str"},
                 "user" : {"required": True, "type": "str"},
                 "password" : {"required": True, "type": "str"},
+                "api_version" : {"required": False, "choices": [ '1.0', '2.0', '3.0', '4.0', '5.0' ], type: "str", "default": '2.0'},
                 "key" : {"required": False, "type": "str"},
                 "name" : {"required": False, "type": "str"},
                 "serial_number" : {"required": False, "type": "str"},
@@ -354,6 +355,7 @@ def main():
         global api_port
         global api_user_name
         global api_user_password
+        global api_version
 
         global lun_key
         global nfs_share_key
@@ -362,6 +364,7 @@ def main():
         api_port                = module.params["port"]
         api_user_name           = module.params["user"]
         api_user_password       = module.params["password"]
+        api_version             = module.params["api_version"]
 
         # Properties details
         global key

--- a/Modules/ClusterPeerModule.py
+++ b/Modules/ClusterPeerModule.py
@@ -27,7 +27,7 @@ warnings.filterwarnings("ignore")
 
 
 def get():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
 
     flag=0
 
@@ -112,7 +112,7 @@ def get():
     return json_response
 
 def post():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="cluster-peers"
 
     payload={}
@@ -146,7 +146,7 @@ def post():
     return json_response
 
 def put():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="cluster-peers/"
 
     payload={}
@@ -183,7 +183,7 @@ def put():
         return "Provide the object key"
 
 def delete():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="cluster-peers/"
 
     if key != None:
@@ -223,6 +223,7 @@ def main():
                 "port" : {"required": True, "type": "str"},
                 "user" : {"required": True, "type": "str"},
                 "password" : {"required": True, "type": "str"},
+                "api_version" : {"required": False, "choices": [ '1.0', '2.0', '3.0', '4.0', '5.0' ], type: "str", "default": '2.0'},
                 "key" : {"required": False, "type": "str"},
                 "cluster_key" : {"required": False, "type": "str"},
                 "peer_cluster_key" : {"required": False, "type": "str"},
@@ -244,6 +245,7 @@ def main():
         global api_port
         global api_user_name
         global api_user_password
+        global api_version
 
         global lun_key
         global nfs_share_key
@@ -252,6 +254,7 @@ def main():
         api_port                = module.params["port"]
         api_user_name           = module.params["user"]
         api_user_password       = module.params["password"]
+        api_version             = module.params["api_version"]
 
         # Properties details
         global key

--- a/Modules/DiskModule.py
+++ b/Modules/DiskModule.py
@@ -27,7 +27,7 @@ warnings.filterwarnings("ignore")
 
 
 def get():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
 
     flag=0
 
@@ -298,7 +298,7 @@ def get():
     return json_response
 
 def post():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="disks"
 
     payload={}
@@ -394,7 +394,7 @@ def post():
     return json_response
 
 def put():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="disks/"
 
     payload={}
@@ -493,7 +493,7 @@ def put():
         return "Provide the object key"
 
 def delete():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="disks/"
 
     if key != None:
@@ -533,6 +533,7 @@ def main():
                 "port" : {"required": True, "type": "str"},
                 "user" : {"required": True, "type": "str"},
                 "password" : {"required": True, "type": "str"},
+                "api_version" : {"required": False, "choices": [ '1.0', '2.0', '3.0', '4.0', '5.0' ], type: "str", "default": '2.0'},
                 "key" : {"required": False, "type": "str"},
                 "storage_pool_key" : {"required": False, "type": "str"},
                 "cluster_key" : {"required": False, "type": "str"},
@@ -585,6 +586,7 @@ def main():
         global api_port
         global api_user_name
         global api_user_password
+        global api_version
 
         global lun_key
         global nfs_share_key
@@ -593,6 +595,7 @@ def main():
         api_port                = module.params["port"]
         api_user_name           = module.params["user"]
         api_user_password       = module.params["password"]
+        api_version             = module.params["api_version"]
 
         # Properties details
         global key

--- a/Modules/EventModule.py
+++ b/Modules/EventModule.py
@@ -27,7 +27,7 @@ warnings.filterwarnings("ignore")
 
 
 def get():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
 
     flag=0
 
@@ -88,7 +88,7 @@ def get():
     return json_response
 
 def post():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="events"
 
     payload={}
@@ -114,7 +114,7 @@ def post():
     return json_response
 
 def put():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="events/"
 
     payload={}
@@ -143,7 +143,7 @@ def put():
         return "Provide the object key"
 
 def delete():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="events/"
 
     if key != None:
@@ -183,6 +183,7 @@ def main():
                 "port" : {"required": True, "type": "str"},
                 "user" : {"required": True, "type": "str"},
                 "password" : {"required": True, "type": "str"},
+                "api_version" : {"required": False, "choices": [ '1.0', '2.0', '3.0', '4.0', '5.0' ], type: "str", "default": '2.0'},
                 "key" : {"required": False, "type": "str"},
                 "severity" : {"required": False, "type": "str"},
                 "created_timestamp" : {"required": False, "type": "str"},
@@ -200,6 +201,7 @@ def main():
         global api_port
         global api_user_name
         global api_user_password
+        global api_version
 
         global lun_key
         global nfs_share_key
@@ -208,6 +210,7 @@ def main():
         api_port                = module.params["port"]
         api_user_name           = module.params["user"]
         api_user_password       = module.params["password"]
+        api_version             = module.params["api_version"]
 
         # Properties details
         global key

--- a/Modules/ExportPolicyModule.py
+++ b/Modules/ExportPolicyModule.py
@@ -27,7 +27,7 @@ warnings.filterwarnings("ignore")
 
 
 def get():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
 
     flag=0
 
@@ -76,7 +76,7 @@ def get():
     return json_response
 
 def post():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="export-policies"
 
     payload={}
@@ -98,7 +98,7 @@ def post():
     return json_response
 
 def put():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="export-policies/"
 
     payload={}
@@ -123,7 +123,7 @@ def put():
         return "Provide the object key"
 
 def delete():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="export-policies/"
 
     if key != None:
@@ -163,6 +163,7 @@ def main():
                 "port" : {"required": True, "type": "str"},
                 "user" : {"required": True, "type": "str"},
                 "password" : {"required": True, "type": "str"},
+                "api_version" : {"required": False, "choices": [ '1.0', '2.0', '3.0', '4.0', '5.0' ], type: "str", "default": '2.0'},
                 "key" : {"required": False, "type": "str"},
                 "storage_vm_key" : {"required": False, "type": "str"},
                 "name" : {"required": False, "type": "str"},
@@ -178,6 +179,7 @@ def main():
         global api_port
         global api_user_name
         global api_user_password
+        global api_version
 
         global lun_key
         global nfs_share_key
@@ -186,6 +188,7 @@ def main():
         api_port                = module.params["port"]
         api_user_name           = module.params["user"]
         api_user_password       = module.params["password"]
+        api_version             = module.params["api_version"]
 
         # Properties details
         global key

--- a/Modules/ExportRuleModule.py
+++ b/Modules/ExportRuleModule.py
@@ -27,7 +27,7 @@ warnings.filterwarnings("ignore")
 
 
 def get():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
 
     flag=0
 
@@ -106,7 +106,7 @@ def get():
     return json_response
 
 def post():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="export-rules"
 
     payload={}
@@ -138,7 +138,7 @@ def post():
     return json_response
 
 def put():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="export-rules/"
 
     payload={}
@@ -173,7 +173,7 @@ def put():
         return "Provide the object key"
 
 def delete():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="export-rules/"
 
     if key != None:
@@ -213,6 +213,7 @@ def main():
                 "port" : {"required": True, "type": "str"},
                 "user" : {"required": True, "type": "str"},
                 "password" : {"required": True, "type": "str"},
+                "api_version" : {"required": False, "choices": [ '1.0', '2.0', '3.0', '4.0', '5.0' ], type: "str", "default": '2.0'},
                 "key" : {"required": False, "type": "str"},
                 "export_policy_key" : {"required": False, "type": "str"},
                 "rule_index" : {"required": False, "type": "str"},
@@ -233,6 +234,7 @@ def main():
         global api_port
         global api_user_name
         global api_user_password
+        global api_version
 
         global lun_key
         global nfs_share_key
@@ -241,6 +243,7 @@ def main():
         api_port                = module.params["port"]
         api_user_name           = module.params["user"]
         api_user_password       = module.params["password"]
+        api_version             = module.params["api_version"]
 
         # Properties details
         global key

--- a/Modules/FCPLifModule.py
+++ b/Modules/FCPLifModule.py
@@ -27,7 +27,7 @@ warnings.filterwarnings("ignore")
 
 
 def get():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
 
     flag=0
 
@@ -112,7 +112,7 @@ def get():
     return json_response
 
 def post():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="fcp-lifs"
 
     payload={}
@@ -146,7 +146,7 @@ def post():
     return json_response
 
 def put():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="fcp-lifs/"
 
     payload={}
@@ -183,7 +183,7 @@ def put():
         return "Provide the object key"
 
 def delete():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="fcp-lifs/"
 
     if key != None:
@@ -223,6 +223,7 @@ def main():
                 "port" : {"required": True, "type": "str"},
                 "user" : {"required": True, "type": "str"},
                 "password" : {"required": True, "type": "str"},
+                "api_version" : {"required": False, "choices": [ '1.0', '2.0', '3.0', '4.0', '5.0' ], type: "str", "default": '2.0'},
                 "key" : {"required": False, "type": "str"},
                 "name" : {"required": False, "type": "str"},
                 "storage_vm_key" : {"required": False, "type": "str"},
@@ -244,6 +245,7 @@ def main():
         global api_port
         global api_user_name
         global api_user_password
+        global api_version
 
         global lun_key
         global nfs_share_key
@@ -252,6 +254,7 @@ def main():
         api_port                = module.params["port"]
         api_user_name           = module.params["user"]
         api_user_password       = module.params["password"]
+        api_version             = module.params["api_version"]
 
         # Properties details
         global key

--- a/Modules/FCPortModule.py
+++ b/Modules/FCPortModule.py
@@ -27,7 +27,7 @@ warnings.filterwarnings("ignore")
 
 
 def get():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
 
     flag=0
 
@@ -154,7 +154,7 @@ def get():
     return json_response
 
 def post():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="fc-ports"
 
     payload={}
@@ -202,7 +202,7 @@ def post():
     return json_response
 
 def put():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="fc-ports/"
 
     payload={}
@@ -253,7 +253,7 @@ def put():
         return "Provide the object key"
 
 def delete():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="fc-ports/"
 
     if key != None:
@@ -293,6 +293,7 @@ def main():
                 "port" : {"required": True, "type": "str"},
                 "user" : {"required": True, "type": "str"},
                 "password" : {"required": True, "type": "str"},
+                "api_version" : {"required": False, "choices": [ '1.0', '2.0', '3.0', '4.0', '5.0' ], type: "str", "default": '2.0'},
                 "key" : {"required": False, "type": "str"},
                 "node_key" : {"required": False, "type": "str"},
                 "wwnn" : {"required": False, "type": "str"},
@@ -321,6 +322,7 @@ def main():
         global api_port
         global api_user_name
         global api_user_password
+        global api_version
 
         global lun_key
         global nfs_share_key
@@ -329,6 +331,7 @@ def main():
         api_port                = module.params["port"]
         api_user_name           = module.params["user"]
         api_user_password       = module.params["password"]
+        api_version             = module.params["api_version"]
 
         # Properties details
         global key

--- a/Modules/FlashDeviceInfoModule.py
+++ b/Modules/FlashDeviceInfoModule.py
@@ -27,7 +27,7 @@ warnings.filterwarnings("ignore")
 
 
 def get():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
 
     flag=0
 
@@ -94,7 +94,7 @@ def get():
     return json_response
 
 def post():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="flash-devices"
 
     payload={}
@@ -122,7 +122,7 @@ def post():
     return json_response
 
 def put():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="flash-devices/"
 
     payload={}
@@ -153,7 +153,7 @@ def put():
         return "Provide the object key"
 
 def delete():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="flash-devices/"
 
     if key != None:
@@ -193,6 +193,7 @@ def main():
                 "port" : {"required": True, "type": "str"},
                 "user" : {"required": True, "type": "str"},
                 "password" : {"required": True, "type": "str"},
+                "api_version" : {"required": False, "choices": [ '1.0', '2.0', '3.0', '4.0', '5.0' ], type: "str", "default": '2.0'},
                 "key" : {"required": False, "type": "str"},
                 "capacity" : {"required": False, "type": "str"},
                 "model_name" : {"required": False, "type": "str"},
@@ -211,6 +212,7 @@ def main():
         global api_port
         global api_user_name
         global api_user_password
+        global api_version
 
         global lun_key
         global nfs_share_key
@@ -219,6 +221,7 @@ def main():
         api_port                = module.params["port"]
         api_user_name           = module.params["user"]
         api_user_password       = module.params["password"]
+        api_version             = module.params["api_version"]
 
         # Properties details
         global key

--- a/Modules/ISCSIPortalGroupModule.py
+++ b/Modules/ISCSIPortalGroupModule.py
@@ -27,7 +27,7 @@ warnings.filterwarnings("ignore")
 
 
 def get():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
 
     flag=0
 
@@ -82,7 +82,7 @@ def get():
     return json_response
 
 def post():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="iscsi-portal-groups"
 
     payload={}
@@ -106,7 +106,7 @@ def post():
     return json_response
 
 def put():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="iscsi-portal-groups/"
 
     payload={}
@@ -133,7 +133,7 @@ def put():
         return "Provide the object key"
 
 def delete():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="iscsi-portal-groups/"
 
     if key != None:
@@ -173,6 +173,7 @@ def main():
                 "port" : {"required": True, "type": "str"},
                 "user" : {"required": True, "type": "str"},
                 "password" : {"required": True, "type": "str"},
+                "api_version" : {"required": False, "choices": [ '1.0', '2.0', '3.0', '4.0', '5.0' ], type: "str", "default": '2.0'},
                 "key" : {"required": False, "type": "str"},
                 "storage_vm_key" : {"required": False, "type": "str"},
                 "name" : {"required": False, "type": "str"},
@@ -189,6 +190,7 @@ def main():
         global api_port
         global api_user_name
         global api_user_password
+        global api_version
 
         global lun_key
         global nfs_share_key
@@ -197,6 +199,7 @@ def main():
         api_port                = module.params["port"]
         api_user_name           = module.params["user"]
         api_user_password       = module.params["password"]
+        api_version             = module.params["api_version"]
 
         # Properties details
         global key

--- a/Modules/ISCSIPortalGroupNetworkLifRelationshipModule.py
+++ b/Modules/ISCSIPortalGroupNetworkLifRelationshipModule.py
@@ -27,7 +27,7 @@ warnings.filterwarnings("ignore")
 
 
 def get():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
 
     flag=0
 
@@ -88,7 +88,7 @@ def get():
     return json_response
 
 def post():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="iscsi-portal-group-network-lif-relationships"
 
     payload={}
@@ -114,7 +114,7 @@ def post():
     return json_response
 
 def put():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="iscsi-portal-group-network-lif-relationships/"
 
     payload={}
@@ -143,7 +143,7 @@ def put():
         return "Provide the object key"
 
 def delete():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="iscsi-portal-group-network-lif-relationships/"
 
     if key != None:
@@ -183,6 +183,7 @@ def main():
                 "port" : {"required": True, "type": "str"},
                 "user" : {"required": True, "type": "str"},
                 "password" : {"required": True, "type": "str"},
+                "api_version" : {"required": False, "choices": [ '1.0', '2.0', '3.0', '4.0', '5.0' ], type: "str", "default": '2.0'},
                 "key" : {"required": False, "type": "str"},
                 "target_portal_group_key" : {"required": False, "type": "str"},
                 "network_lif_key" : {"required": False, "type": "str"},
@@ -200,6 +201,7 @@ def main():
         global api_port
         global api_user_name
         global api_user_password
+        global api_version
 
         global lun_key
         global nfs_share_key
@@ -208,6 +210,7 @@ def main():
         api_port                = module.params["port"]
         api_user_name           = module.params["user"]
         api_user_password       = module.params["password"]
+        api_version             = module.params["api_version"]
 
         # Properties details
         global key

--- a/Modules/IgroupModule.py
+++ b/Modules/IgroupModule.py
@@ -27,7 +27,7 @@ warnings.filterwarnings("ignore")
 
 
 def get():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
 
     flag=0
 
@@ -118,7 +118,7 @@ def get():
     return json_response
 
 def post():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="igroups"
 
     payload={}
@@ -154,7 +154,7 @@ def post():
     return json_response
 
 def put():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="igroups/"
 
     payload={}
@@ -193,7 +193,7 @@ def put():
         return "Provide the object key"
 
 def delete():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="igroups/"
 
     if key != None:
@@ -233,6 +233,7 @@ def main():
                 "port" : {"required": True, "type": "str"},
                 "user" : {"required": True, "type": "str"},
                 "password" : {"required": True, "type": "str"},
+                "api_version" : {"required": False, "choices": [ '1.0', '2.0', '3.0', '4.0', '5.0' ], type: "str", "default": '2.0'},
                 "key" : {"required": False, "type": "str"},
                 "name" : {"required": False, "type": "str"},
                 "storage_vm_key" : {"required": False, "type": "str"},
@@ -255,6 +256,7 @@ def main():
         global api_port
         global api_user_name
         global api_user_password
+        global api_version
 
         global lun_key
         global nfs_share_key
@@ -263,6 +265,7 @@ def main():
         api_port                = module.params["port"]
         api_user_name           = module.params["user"]
         api_user_password       = module.params["password"]
+        api_version             = module.params["api_version"]
 
         # Properties details
         global key

--- a/Modules/IgroupPortSetRelationshipModule.py
+++ b/Modules/IgroupPortSetRelationshipModule.py
@@ -27,7 +27,7 @@ warnings.filterwarnings("ignore")
 
 
 def get():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
 
     flag=0
 
@@ -76,7 +76,7 @@ def get():
     return json_response
 
 def post():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="igroup-port-set-relationships"
 
     payload={}
@@ -98,7 +98,7 @@ def post():
     return json_response
 
 def put():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="igroup-port-set-relationships/"
 
     payload={}
@@ -123,7 +123,7 @@ def put():
         return "Provide the object key"
 
 def delete():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="igroup-port-set-relationships/"
 
     if key != None:
@@ -163,6 +163,7 @@ def main():
                 "port" : {"required": True, "type": "str"},
                 "user" : {"required": True, "type": "str"},
                 "password" : {"required": True, "type": "str"},
+                "api_version" : {"required": False, "choices": [ '1.0', '2.0', '3.0', '4.0', '5.0' ], type: "str", "default": '5.0'},
                 "key" : {"required": False, "type": "str"},
                 "igroup_key" : {"required": False, "type": "str"},
                 "portset_key" : {"required": False, "type": "str"},
@@ -178,6 +179,7 @@ def main():
         global api_port
         global api_user_name
         global api_user_password
+        global api_version
 
         global lun_key
         global nfs_share_key
@@ -186,6 +188,7 @@ def main():
         api_port                = module.params["port"]
         api_user_name           = module.params["user"]
         api_user_password       = module.params["password"]
+        api_version             = module.params["api_version"]
 
         # Properties details
         global key

--- a/Modules/JobScheduleModule.py
+++ b/Modules/JobScheduleModule.py
@@ -27,11 +27,11 @@ warnings.filterwarnings("ignore")
 
 
 def get():
-    url_path        = "/api/1.0/"
+    url_path = "/api/" + api_version + "/ontap/"
 
     flag=0
 
-    url_path+="jobs"
+    url_path+="job-schedules"
 
     flag=0
 
@@ -142,8 +142,8 @@ def get():
     return json_response
 
 def post():
-    url_path        = "/api/1.0/"
-    url_path+="jobs"
+    url_path = "/api/" + api_version + "/ontap/"
+    url_path+="job-schedules/"
 
     payload={}
     if (key != None) & (key != key):
@@ -186,8 +186,8 @@ def post():
     return json_response
 
 def put():
-    url_path        = "/api/1.0/"
-    url_path+="jobs/"
+    url_path = "/api/" + api_version + "/ontap/"
+    url_path+="job-schedules"
 
     payload={}
     if (key != None) & (key != key):
@@ -233,8 +233,8 @@ def put():
         return "Provide the object key"
 
 def delete():
-    url_path        = "/api/1.0/"
-    url_path+="jobs/"
+    url_path = "/api/" + api_version + "/ontap/"
+    url_path+="job-schedules/"
 
     if key != None:
         url_path+=key
@@ -273,6 +273,7 @@ def main():
                 "port" : {"required": True, "type": "str"},
                 "user" : {"required": True, "type": "str"},
                 "password" : {"required": True, "type": "str"},
+                "api_version" : {"required": False, "choices": [ '1.0', '2.0', '3.0', '4.0', '5.0' ], type: "str", "default": '2.0'},
                 "key" : {"required": False, "type": "str"},
                 "name" : {"required": False, "type": "str"},
                 "cluster_key" : {"required": False, "type": "str"},
@@ -299,6 +300,7 @@ def main():
         global api_port
         global api_user_name
         global api_user_password
+        global api_version
 
         global lun_key
         global nfs_share_key
@@ -307,6 +309,7 @@ def main():
         api_port                = module.params["port"]
         api_user_name           = module.params["user"]
         api_user_password       = module.params["password"]
+        api_version             = module.params["api_version"]
 
         # Properties details
         global key

--- a/Modules/LUNModule.py
+++ b/Modules/LUNModule.py
@@ -27,7 +27,7 @@ warnings.filterwarnings("ignore")
 
 
 def get():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
 
     flag=0
 
@@ -178,7 +178,7 @@ def get():
     return json_response
 
 def post():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="luns"
 
     payload={}
@@ -234,7 +234,7 @@ def post():
     return json_response
 
 def put():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="luns/"
 
     payload={}
@@ -293,7 +293,7 @@ def put():
         return "Provide the object key"
 
 def delete():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="luns/"
 
     if key != None:
@@ -333,6 +333,7 @@ def main():
                 "port" : {"required": True, "type": "str"},
                 "user" : {"required": True, "type": "str"},
                 "password" : {"required": True, "type": "str"},
+                "api_version" : {"required": False, "choices": [ '1.0', '2.0', '3.0', '4.0', '5.0' ], type: "str", "default": '2.0'},
                 "key" : {"required": False, "type": "str"},
                 "qtree_key" : {"required": False, "type": "str"},
                 "volume_key" : {"required": False, "type": "str"},
@@ -365,6 +366,7 @@ def main():
         global api_port
         global api_user_name
         global api_user_password
+        global api_version
 
         global lun_key
         global nfs_share_key
@@ -373,6 +375,7 @@ def main():
         api_port                = module.params["port"]
         api_user_name           = module.params["user"]
         api_user_password       = module.params["password"]
+        api_version             = module.params["api_version"]
 
         # Properties details
         global key

--- a/Modules/LunMapModule.py
+++ b/Modules/LunMapModule.py
@@ -27,7 +27,7 @@ warnings.filterwarnings("ignore")
 
 
 def get():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
 
     flag=0
 
@@ -88,7 +88,7 @@ def get():
     return json_response
 
 def post():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="lun-maps"
 
     payload={}
@@ -114,7 +114,7 @@ def post():
     return json_response
 
 def put():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="lun-maps/"
 
     payload={}
@@ -143,7 +143,7 @@ def put():
         return "Provide the object key"
 
 def delete():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="lun-maps/"
 
     if key != None:
@@ -183,6 +183,7 @@ def main():
                 "port" : {"required": True, "type": "str"},
                 "user" : {"required": True, "type": "str"},
                 "password" : {"required": True, "type": "str"},
+                "api_version" : {"required": False, "choices": [ '1.0', '2.0', '3.0', '4.0', '5.0' ], type: "str", "default": '2.0'},
                 "key" : {"required": False, "type": "str"},
                 "storage_vm_key" : {"required": False, "type": "str"},
                 "igroup_key" : {"required": False, "type": "str"},
@@ -200,6 +201,7 @@ def main():
         global api_port
         global api_user_name
         global api_user_password
+        global api_version
 
         global lun_key
         global nfs_share_key
@@ -208,6 +210,7 @@ def main():
         api_port                = module.params["port"]
         api_user_name           = module.params["user"]
         api_user_password       = module.params["password"]
+        api_version             = module.params["api_version"]
 
         # Properties details
         global key

--- a/Modules/LunMapNodeRelationshipModule.py
+++ b/Modules/LunMapNodeRelationshipModule.py
@@ -27,7 +27,7 @@ warnings.filterwarnings("ignore")
 
 
 def get():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
 
     flag=0
 
@@ -76,7 +76,7 @@ def get():
     return json_response
 
 def post():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="lun-map-node-relationships"
 
     payload={}
@@ -98,7 +98,7 @@ def post():
     return json_response
 
 def put():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="lun-map-node-relationships/"
 
     payload={}
@@ -123,7 +123,7 @@ def put():
         return "Provide the object key"
 
 def delete():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="lun-map-node-relationships/"
 
     if key != None:
@@ -163,6 +163,7 @@ def main():
                 "port" : {"required": True, "type": "str"},
                 "user" : {"required": True, "type": "str"},
                 "password" : {"required": True, "type": "str"},
+                "api_version" : {"required": False, "choices": [ '1.0', '2.0', '3.0', '4.0', '5.0' ], type: "str", "default": '2.0'},
                 "key" : {"required": False, "type": "str"},
                 "lunmap_key" : {"required": False, "type": "str"},
                 "node_key" : {"required": False, "type": "str"},
@@ -178,6 +179,7 @@ def main():
         global api_port
         global api_user_name
         global api_user_password
+        global api_version
 
         global lun_key
         global nfs_share_key
@@ -186,6 +188,7 @@ def main():
         api_port                = module.params["port"]
         api_user_name           = module.params["user"]
         api_user_password       = module.params["password"]
+        api_version             = module.params["api_version"]
 
         # Properties details
         global key

--- a/Modules/NetworkBroadcastDomainModule.py
+++ b/Modules/NetworkBroadcastDomainModule.py
@@ -27,7 +27,7 @@ warnings.filterwarnings("ignore")
 
 
 def get():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
 
     flag=0
 
@@ -82,7 +82,7 @@ def get():
     return json_response
 
 def post():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="network-broadcast-domains"
 
     payload={}
@@ -106,7 +106,7 @@ def post():
     return json_response
 
 def put():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="network-broadcast-domains/"
 
     payload={}
@@ -133,7 +133,7 @@ def put():
         return "Provide the object key"
 
 def delete():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="network-broadcast-domains/"
 
     if key != None:
@@ -173,6 +173,7 @@ def main():
                 "port" : {"required": True, "type": "str"},
                 "user" : {"required": True, "type": "str"},
                 "password" : {"required": True, "type": "str"},
+                "api_version" : {"required": False, "choices": [ '1.0', '2.0', '3.0', '4.0', '5.0' ], type: "str", "default": '2.0'},
                 "key" : {"required": False, "type": "str"},
                 "name" : {"required": False, "type": "str"},
                 "mtu" : {"required": False, "type": "str"},
@@ -189,6 +190,7 @@ def main():
         global api_port
         global api_user_name
         global api_user_password
+        global api_version
 
         global lun_key
         global nfs_share_key
@@ -197,6 +199,7 @@ def main():
         api_port                = module.params["port"]
         api_user_name           = module.params["user"]
         api_user_password       = module.params["password"]
+        api_version             = module.params["api_version"]
 
         # Properties details
         global key

--- a/Modules/NetworkFailoverGroupModule.py
+++ b/Modules/NetworkFailoverGroupModule.py
@@ -27,7 +27,7 @@ warnings.filterwarnings("ignore")
 
 
 def get():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
 
     flag=0
 
@@ -82,7 +82,7 @@ def get():
     return json_response
 
 def post():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="network-failover-groups"
 
     payload={}
@@ -106,7 +106,7 @@ def post():
     return json_response
 
 def put():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="network-failover-groups/"
 
     payload={}
@@ -133,7 +133,7 @@ def put():
         return "Provide the object key"
 
 def delete():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="network-failover-groups/"
 
     if key != None:
@@ -173,6 +173,7 @@ def main():
                 "port" : {"required": True, "type": "str"},
                 "user" : {"required": True, "type": "str"},
                 "password" : {"required": True, "type": "str"},
+                "api_version" : {"required": False, "choices": [ '1.0', '2.0', '3.0', '4.0', '5.0' ], type: "str", "default": '2.0'},
                 "key" : {"required": False, "type": "str"},
                 "name" : {"required": False, "type": "str"},
                 "cluster_key" : {"required": False, "type": "str"},
@@ -189,6 +190,7 @@ def main():
         global api_port
         global api_user_name
         global api_user_password
+        global api_version
 
         global lun_key
         global nfs_share_key
@@ -197,6 +199,7 @@ def main():
         api_port                = module.params["port"]
         api_user_name           = module.params["user"]
         api_user_password       = module.params["password"]
+        api_version             = module.params["api_version"]
 
         # Properties details
         global key

--- a/Modules/NetworkIPSpaceModule.py
+++ b/Modules/NetworkIPSpaceModule.py
@@ -27,7 +27,7 @@ warnings.filterwarnings("ignore")
 
 
 def get():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
 
     flag=0
 
@@ -70,7 +70,7 @@ def get():
     return json_response
 
 def post():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="network-ip-spaces"
 
     payload={}
@@ -90,7 +90,7 @@ def post():
     return json_response
 
 def put():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="network-ip-spaces/"
 
     payload={}
@@ -113,7 +113,7 @@ def put():
         return "Provide the object key"
 
 def delete():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="network-ip-spaces/"
 
     if key != None:
@@ -153,6 +153,7 @@ def main():
                 "port" : {"required": True, "type": "str"},
                 "user" : {"required": True, "type": "str"},
                 "password" : {"required": True, "type": "str"},
+                "api_version" : {"required": False, "choices": [ '1.0', '2.0', '3.0', '4.0', '5.0' ], type: "str", "default": '2.0'},
                 "key" : {"required": False, "type": "str"},
                 "name" : {"required": False, "type": "str"},
                 "sortBy" : {"required": False, "type": "str"},
@@ -167,6 +168,7 @@ def main():
         global api_port
         global api_user_name
         global api_user_password
+        global api_version
 
         global lun_key
         global nfs_share_key
@@ -175,6 +177,7 @@ def main():
         api_port                = module.params["port"]
         api_user_name           = module.params["user"]
         api_user_password       = module.params["password"]
+        api_version             = module.params["api_version"]
 
         # Properties details
         global key

--- a/Modules/NetworkLifModule.py
+++ b/Modules/NetworkLifModule.py
@@ -27,7 +27,7 @@ warnings.filterwarnings("ignore")
 
 
 def get():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
 
     flag=0
 
@@ -172,7 +172,7 @@ def get():
     return json_response
 
 def post():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="network-lifs"
 
     payload={}
@@ -226,7 +226,7 @@ def post():
     return json_response
 
 def put():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="network-lifs/"
 
     payload={}
@@ -283,7 +283,7 @@ def put():
         return "Provide the object key"
 
 def delete():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="network-lifs/"
 
     if key != None:
@@ -323,6 +323,7 @@ def main():
                 "port" : {"required": True, "type": "str"},
                 "user" : {"required": True, "type": "str"},
                 "password" : {"required": True, "type": "str"},
+                "api_version" : {"required": False, "choices": [ '1.0', '2.0', '3.0', '4.0', '5.0' ], type: "str", "default": '2.0'},
                 "key" : {"required": False, "type": "str"},
                 "name" : {"required": False, "type": "str"},
                 "storage_vm_key" : {"required": False, "type": "str"},
@@ -354,6 +355,7 @@ def main():
         global api_port
         global api_user_name
         global api_user_password
+        global api_version
 
         global lun_key
         global nfs_share_key
@@ -362,6 +364,7 @@ def main():
         api_port                = module.params["port"]
         api_user_name           = module.params["user"]
         api_user_password       = module.params["password"]
+        api_version             = module.params["api_version"]
 
         # Properties details
         global key

--- a/Modules/NetworkPortModule.py
+++ b/Modules/NetworkPortModule.py
@@ -27,7 +27,7 @@ warnings.filterwarnings("ignore")
 
 
 def get():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
 
     flag=0
 
@@ -148,7 +148,7 @@ def get():
     return json_response
 
 def post():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="network-ports"
 
     payload={}
@@ -194,7 +194,7 @@ def post():
     return json_response
 
 def put():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="network-ports/"
 
     payload={}
@@ -243,7 +243,7 @@ def put():
         return "Provide the object key"
 
 def delete():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="network-ports/"
 
     if key != None:
@@ -283,6 +283,7 @@ def main():
                 "port" : {"required": True, "type": "str"},
                 "user" : {"required": True, "type": "str"},
                 "password" : {"required": True, "type": "str"},
+                "api_version" : {"required": False, "choices": [ '1.0', '2.0', '3.0', '4.0', '5.0' ], type: "str", "default": '2.0'},
                 "key" : {"required": False, "type": "str"},
                 "name" : {"required": False, "type": "str"},
                 "node_key" : {"required": False, "type": "str"},
@@ -310,6 +311,7 @@ def main():
         global api_port
         global api_user_name
         global api_user_password
+        global api_version
 
         global lun_key
         global nfs_share_key
@@ -318,6 +320,7 @@ def main():
         api_port                = module.params["port"]
         api_user_name           = module.params["user"]
         api_user_password       = module.params["password"]
+        api_version             = module.params["api_version"]
 
         # Properties details
         global key

--- a/Modules/NetworkSubnetModule.py
+++ b/Modules/NetworkSubnetModule.py
@@ -27,7 +27,7 @@ warnings.filterwarnings("ignore")
 
 
 def get():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
 
     flag=0
 
@@ -112,7 +112,7 @@ def get():
     return json_response
 
 def post():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="network-subnets"
 
     payload={}
@@ -146,7 +146,7 @@ def post():
     return json_response
 
 def put():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="network-subnets/"
 
     payload={}
@@ -183,7 +183,7 @@ def put():
         return "Provide the object key"
 
 def delete():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="network-subnets/"
 
     if key != None:
@@ -223,6 +223,7 @@ def main():
                 "port" : {"required": True, "type": "str"},
                 "user" : {"required": True, "type": "str"},
                 "password" : {"required": True, "type": "str"},
+                "api_version" : {"required": False, "choices": [ '1.0', '2.0', '3.0', '4.0', '5.0' ], type: "str", "default": '2.0'},
                 "key" : {"required": False, "type": "str"},
                 "name" : {"required": False, "type": "str"},
                 "network_broadcast_domain_key" : {"required": False, "type": "str"},
@@ -244,6 +245,7 @@ def main():
         global api_port
         global api_user_name
         global api_user_password
+        global api_version
 
         global lun_key
         global nfs_share_key
@@ -252,6 +254,7 @@ def main():
         api_port                = module.params["port"]
         api_user_name           = module.params["user"]
         api_user_password       = module.params["password"]
+        api_version             = module.params["api_version"]
 
         # Properties details
         global key

--- a/Modules/NodeModule.py
+++ b/Modules/NodeModule.py
@@ -27,7 +27,7 @@ warnings.filterwarnings("ignore")
 
 
 def get():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
 
     flag=0
 
@@ -328,7 +328,7 @@ def get():
     return json_response
 
 def post():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="nodes"
 
     payload={}
@@ -434,7 +434,7 @@ def post():
     return json_response
 
 def put():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="nodes/"
 
     payload={}
@@ -543,7 +543,7 @@ def put():
         return "Provide the object key"
 
 def delete():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="nodes/"
 
     if key != None:
@@ -583,6 +583,7 @@ def main():
                 "port" : {"required": True, "type": "str"},
                 "user" : {"required": True, "type": "str"},
                 "password" : {"required": True, "type": "str"},
+                "api_version" : {"required": False, "choices": [ '1.0', '2.0', '3.0', '4.0', '5.0' ], type: "str", "default": '2.0'},
                 "key" : {"required": False, "type": "str"},
                 "name" : {"required": False, "type": "str"},
                 "cluster_key" : {"required": False, "type": "str"},
@@ -640,6 +641,7 @@ def main():
         global api_port
         global api_user_name
         global api_user_password
+        global api_version
 
         global lun_key
         global nfs_share_key
@@ -648,6 +650,7 @@ def main():
         api_port                = module.params["port"]
         api_user_name           = module.params["user"]
         api_user_password       = module.params["password"]
+        api_version             = module.params["api_version"]
 
         # Properties details
         global key

--- a/Modules/PortSetFCPLifRelationshipModule.py
+++ b/Modules/PortSetFCPLifRelationshipModule.py
@@ -27,7 +27,7 @@ warnings.filterwarnings("ignore")
 
 
 def get():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
 
     flag=0
 
@@ -76,7 +76,7 @@ def get():
     return json_response
 
 def post():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="port-set-fcp-lif-relationships"
 
     payload={}
@@ -98,7 +98,7 @@ def post():
     return json_response
 
 def put():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="port-set-fcp-lif-relationships/"
 
     payload={}
@@ -123,7 +123,7 @@ def put():
         return "Provide the object key"
 
 def delete():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="port-set-fcp-lif-relationships/"
 
     if key != None:
@@ -163,6 +163,7 @@ def main():
                 "port" : {"required": True, "type": "str"},
                 "user" : {"required": True, "type": "str"},
                 "password" : {"required": True, "type": "str"},
+                "api_version" : {"required": False, "choices": [ '1.0', '2.0', '3.0', '4.0', '5.0' ], type: "str", "default": '2.0'},
                 "key" : {"required": False, "type": "str"},
                 "portset_key" : {"required": False, "type": "str"},
                 "fcp_lif_key" : {"required": False, "type": "str"},
@@ -178,6 +179,7 @@ def main():
         global api_port
         global api_user_name
         global api_user_password
+        global api_version
 
         global lun_key
         global nfs_share_key
@@ -186,6 +188,7 @@ def main():
         api_port                = module.params["port"]
         api_user_name           = module.params["user"]
         api_user_password       = module.params["password"]
+        api_version             = module.params["api_version"]
 
         # Properties details
         global key

--- a/Modules/PortSetISCSIPortalGroupRelationshipModule.py
+++ b/Modules/PortSetISCSIPortalGroupRelationshipModule.py
@@ -27,7 +27,7 @@ warnings.filterwarnings("ignore")
 
 
 def get():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
 
     flag=0
 
@@ -76,7 +76,7 @@ def get():
     return json_response
 
 def post():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="port-set-iscsi-portal-group-relationships"
 
     payload={}
@@ -98,7 +98,7 @@ def post():
     return json_response
 
 def put():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="port-set-iscsi-portal-group-relationships/"
 
     payload={}
@@ -123,7 +123,7 @@ def put():
         return "Provide the object key"
 
 def delete():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="port-set-iscsi-portal-group-relationships/"
 
     if key != None:
@@ -163,6 +163,7 @@ def main():
                 "port" : {"required": True, "type": "str"},
                 "user" : {"required": True, "type": "str"},
                 "password" : {"required": True, "type": "str"},
+                "api_version" : {"required": False, "choices": [ '1.0', '2.0', '3.0', '4.0', '5.0' ], type: "str", "default": '2.0'},
                 "key" : {"required": False, "type": "str"},
                 "portset_key" : {"required": False, "type": "str"},
                 "iscsi_portal_group_key" : {"required": False, "type": "str"},
@@ -178,6 +179,7 @@ def main():
         global api_port
         global api_user_name
         global api_user_password
+        global api_version
 
         global lun_key
         global nfs_share_key
@@ -186,6 +188,7 @@ def main():
         api_port                = module.params["port"]
         api_user_name           = module.params["user"]
         api_user_password       = module.params["password"]
+        api_version             = module.params["api_version"]
 
         # Properties details
         global key

--- a/Modules/PortSetModule.py
+++ b/Modules/PortSetModule.py
@@ -27,7 +27,7 @@ warnings.filterwarnings("ignore")
 
 
 def get():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
 
     flag=0
 
@@ -82,7 +82,7 @@ def get():
     return json_response
 
 def post():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="port-sets"
 
     payload={}
@@ -106,7 +106,7 @@ def post():
     return json_response
 
 def put():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="port-sets/"
 
     payload={}
@@ -133,7 +133,7 @@ def put():
         return "Provide the object key"
 
 def delete():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="port-sets/"
 
     if key != None:
@@ -173,6 +173,7 @@ def main():
                 "port" : {"required": True, "type": "str"},
                 "user" : {"required": True, "type": "str"},
                 "password" : {"required": True, "type": "str"},
+                "api_version" : {"required": False, "choices": [ '1.0', '2.0', '3.0', '4.0', '5.0' ], type: "str", "default": '2.0'},
                 "key" : {"required": False, "type": "str"},
                 "name" : {"required": False, "type": "str"},
                 "storage_vm_key" : {"required": False, "type": "str"},
@@ -189,6 +190,7 @@ def main():
         global api_port
         global api_user_name
         global api_user_password
+        global api_version
 
         global lun_key
         global nfs_share_key
@@ -197,6 +199,7 @@ def main():
         api_port                = module.params["port"]
         api_user_name           = module.params["user"]
         api_user_password       = module.params["password"]
+        api_version             = module.params["api_version"]
 
         # Properties details
         global key

--- a/Modules/QosPolicyGroupModule.py
+++ b/Modules/QosPolicyGroupModule.py
@@ -27,7 +27,7 @@ warnings.filterwarnings("ignore")
 
 
 def get():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
 
     flag=0
 
@@ -100,7 +100,7 @@ def get():
     return json_response
 
 def post():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="qos-policy-groups"
 
     payload={}
@@ -130,7 +130,7 @@ def post():
     return json_response
 
 def put():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="qos-policy-groups/"
 
     payload={}
@@ -163,7 +163,7 @@ def put():
         return "Provide the object key"
 
 def delete():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="qos-policy-groups/"
 
     if key != None:
@@ -203,6 +203,7 @@ def main():
                 "port" : {"required": True, "type": "str"},
                 "user" : {"required": True, "type": "str"},
                 "password" : {"required": True, "type": "str"},
+                "api_version" : {"required": False, "choices": [ '1.0', '2.0', '3.0', '4.0', '5.0' ], type: "str", "default": '2.0'},
                 "key" : {"required": False, "type": "str"},
                 "storage_vm_key" : {"required": False, "type": "str"},
                 "cluster_key" : {"required": False, "type": "str"},
@@ -222,6 +223,7 @@ def main():
         global api_port
         global api_user_name
         global api_user_password
+        global api_version
 
         global lun_key
         global nfs_share_key
@@ -229,7 +231,7 @@ def main():
         api_host                = module.params["host"]
         api_port                = module.params["port"]
         api_user_name           = module.params["user"]
-        api_user_password       = module.params["password"]
+        api_version             = module.params["api_version"]
 
         # Properties details
         global key

--- a/Modules/QtreeModule.py
+++ b/Modules/QtreeModule.py
@@ -27,7 +27,7 @@ warnings.filterwarnings("ignore")
 
 
 def get():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
 
     flag=0
 
@@ -148,7 +148,7 @@ def get():
     return json_response
 
 def post():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="qtrees"
 
     payload={}
@@ -194,7 +194,7 @@ def post():
     return json_response
 
 def put():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="qtrees/"
 
     payload={}
@@ -243,7 +243,7 @@ def put():
         return "Provide the object key"
 
 def delete():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="qtrees/"
 
     if key != None:
@@ -283,6 +283,7 @@ def main():
                 "port" : {"required": True, "type": "str"},
                 "user" : {"required": True, "type": "str"},
                 "password" : {"required": True, "type": "str"},
+                "api_version" : {"required": False, "choices": [ '1.0', '2.0', '3.0', '4.0', '5.0' ], type: "str", "default": '2.0'},
                 "key" : {"required": False, "type": "str"},
                 "name" : {"required": False, "type": "str"},
                 "volume_key" : {"required": False, "type": "str"},
@@ -310,6 +311,7 @@ def main():
         global api_port
         global api_user_name
         global api_user_password
+        global api_version
 
         global lun_key
         global nfs_share_key
@@ -318,6 +320,7 @@ def main():
         api_port                = module.params["port"]
         api_user_name           = module.params["user"]
         api_user_password       = module.params["password"]
+        api_version             = module.params["api_version"]
 
         # Properties details
         global key

--- a/Modules/RouteModule.py
+++ b/Modules/RouteModule.py
@@ -27,7 +27,7 @@ warnings.filterwarnings("ignore")
 
 
 def get():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
 
     flag=0
 
@@ -88,7 +88,7 @@ def get():
     return json_response
 
 def post():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="routes"
 
     payload={}
@@ -114,7 +114,7 @@ def post():
     return json_response
 
 def put():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="routes/"
 
     payload={}
@@ -143,7 +143,7 @@ def put():
         return "Provide the object key"
 
 def delete():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="routes/"
 
     if key != None:
@@ -183,6 +183,7 @@ def main():
                 "port" : {"required": True, "type": "str"},
                 "user" : {"required": True, "type": "str"},
                 "password" : {"required": True, "type": "str"},
+                "api_version" : {"required": False, "choices": [ '1.0', '2.0', '3.0', '4.0', '5.0' ], type: "str", "default": '2.0'},
                 "key" : {"required": False, "type": "str"},
                 "storage_vm_key" : {"required": False, "type": "str"},
                 "routing_group_key" : {"required": False, "type": "str"},
@@ -200,6 +201,7 @@ def main():
         global api_port
         global api_user_name
         global api_user_password
+        global api_version
 
         global lun_key
         global nfs_share_key
@@ -208,6 +210,7 @@ def main():
         api_port                = module.params["port"]
         api_user_name           = module.params["user"]
         api_user_password       = module.params["password"]
+        api_version             = module.params["api_version"]
 
         # Properties details
         global key

--- a/Modules/RoutingGroupModule.py
+++ b/Modules/RoutingGroupModule.py
@@ -27,7 +27,7 @@ warnings.filterwarnings("ignore")
 
 
 def get():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
 
     flag=0
 
@@ -82,7 +82,7 @@ def get():
     return json_response
 
 def post():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="routing-groups"
 
     payload={}
@@ -106,7 +106,7 @@ def post():
     return json_response
 
 def put():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="routing-groups/"
 
     payload={}
@@ -133,7 +133,7 @@ def put():
         return "Provide the object key"
 
 def delete():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="routing-groups/"
 
     if key != None:
@@ -173,6 +173,7 @@ def main():
                 "port" : {"required": True, "type": "str"},
                 "user" : {"required": True, "type": "str"},
                 "password" : {"required": True, "type": "str"},
+                "api_version" : {"required": False, "choices": [ '1.0', '2.0', '3.0', '4.0', '5.0' ], type: "str", "default": '2.0'},
                 "key" : {"required": False, "type": "str"},
                 "storage_vm_key" : {"required": False, "type": "str"},
                 "routing_group_name" : {"required": False, "type": "str"},
@@ -189,6 +190,7 @@ def main():
         global api_port
         global api_user_name
         global api_user_password
+        global api_version
 
         global lun_key
         global nfs_share_key
@@ -197,6 +199,7 @@ def main():
         api_port                = module.params["port"]
         api_user_name           = module.params["user"]
         api_user_password       = module.params["password"]
+        api_version             = module.params["api_version"]
 
         # Properties details
         global key

--- a/Modules/SISPolicyModule.py
+++ b/Modules/SISPolicyModule.py
@@ -27,7 +27,7 @@ warnings.filterwarnings("ignore")
 
 
 def get():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
 
     flag=0
 
@@ -106,7 +106,7 @@ def get():
     return json_response
 
 def post():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="sis-policies"
 
     payload={}
@@ -138,7 +138,7 @@ def post():
     return json_response
 
 def put():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="sis-policies/"
 
     payload={}
@@ -173,7 +173,7 @@ def put():
         return "Provide the object key"
 
 def delete():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="sis-policies/"
 
     if key != None:
@@ -213,6 +213,7 @@ def main():
                 "port" : {"required": True, "type": "str"},
                 "user" : {"required": True, "type": "str"},
                 "password" : {"required": True, "type": "str"},
+                "api_version" : {"required": False, "choices": [ '1.0', '2.0', '3.0', '4.0', '5.0' ], type: "str", "default": '2.0'},
                 "key" : {"required": False, "type": "str"},
                 "name" : {"required": False, "type": "str"},
                 "storage_vm_key" : {"required": False, "type": "str"},
@@ -233,6 +234,7 @@ def main():
         global api_port
         global api_user_name
         global api_user_password
+        global api_version
 
         global lun_key
         global nfs_share_key
@@ -241,6 +243,7 @@ def main():
         api_port                = module.params["port"]
         api_user_name           = module.params["user"]
         api_user_password       = module.params["password"]
+        api_version             = module.params["api_version"]
 
         # Properties details
         global key

--- a/Modules/SnapMirrorModule.py
+++ b/Modules/SnapMirrorModule.py
@@ -27,7 +27,7 @@ warnings.filterwarnings("ignore")
 
 
 def get():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
 
     flag=0
 
@@ -220,7 +220,7 @@ def get():
     return json_response
 
 def post():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="snap-mirrors"
 
     payload={}
@@ -290,7 +290,7 @@ def post():
     return json_response
 
 def put():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="snap-mirrors/"
 
     payload={}
@@ -363,7 +363,7 @@ def put():
         return "Provide the object key"
 
 def delete():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="snap-mirrors/"
 
     if key != None:
@@ -403,6 +403,7 @@ def main():
                 "port" : {"required": True, "type": "str"},
                 "user" : {"required": True, "type": "str"},
                 "password" : {"required": True, "type": "str"},
+                "api_version" : {"required": False, "choices": [ '1.0', '2.0', '3.0', '4.0', '5.0' ], type: "str", "default": '2.0'},
                 "key" : {"required": False, "type": "str"},
                 "storage_vm_snap_mirror_key" : {"required": False, "type": "str"},
                 "destination_volume_key" : {"required": False, "type": "str"},
@@ -442,6 +443,7 @@ def main():
         global api_port
         global api_user_name
         global api_user_password
+        global api_version
 
         global lun_key
         global nfs_share_key
@@ -450,6 +452,7 @@ def main():
         api_port                = module.params["port"]
         api_user_name           = module.params["user"]
         api_user_password       = module.params["password"]
+        api_version             = module.params["api_version"]
 
         # Properties details
         global key

--- a/Modules/SnapMirrorPolicyModule.py
+++ b/Modules/SnapMirrorPolicyModule.py
@@ -27,7 +27,7 @@ warnings.filterwarnings("ignore")
 
 
 def get():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
 
     flag=0
 
@@ -130,7 +130,7 @@ def get():
     return json_response
 
 def post():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="snap-mirror-policies"
 
     payload={}
@@ -170,7 +170,7 @@ def post():
     return json_response
 
 def put():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="snap-mirror-policies/"
 
     payload={}
@@ -213,7 +213,7 @@ def put():
         return "Provide the object key"
 
 def delete():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="snap-mirror-policies/"
 
     if key != None:
@@ -253,6 +253,7 @@ def main():
                 "port" : {"required": True, "type": "str"},
                 "user" : {"required": True, "type": "str"},
                 "password" : {"required": True, "type": "str"},
+                "api_version" : {"required": False, "choices": [ '1.0', '2.0', '3.0', '4.0', '5.0' ], type: "str", "default": '2.0'},
                 "key" : {"required": False, "type": "str"},
                 "storage_vm_key" : {"required": False, "type": "str"},
                 "name" : {"required": False, "type": "str"},
@@ -277,6 +278,7 @@ def main():
         global api_port
         global api_user_name
         global api_user_password
+        global api_version
 
         global lun_key
         global nfs_share_key
@@ -285,6 +287,7 @@ def main():
         api_port                = module.params["port"]
         api_user_name           = module.params["user"]
         api_user_password       = module.params["password"]
+        api_version             = module.params["api_version"]
 
         # Properties details
         global key

--- a/Modules/SnapMirrorPolicyRulesModule.py
+++ b/Modules/SnapMirrorPolicyRulesModule.py
@@ -27,7 +27,7 @@ warnings.filterwarnings("ignore")
 
 
 def get():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
 
     flag=0
 
@@ -94,7 +94,7 @@ def get():
     return json_response
 
 def post():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="snap-mirror-policy-rules"
 
     payload={}
@@ -122,7 +122,7 @@ def post():
     return json_response
 
 def put():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="snap-mirror-policy-rules/"
 
     payload={}
@@ -153,7 +153,7 @@ def put():
         return "Provide the object key"
 
 def delete():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="snap-mirror-policy-rules/"
 
     if key != None:
@@ -193,6 +193,7 @@ def main():
                 "port" : {"required": True, "type": "str"},
                 "user" : {"required": True, "type": "str"},
                 "password" : {"required": True, "type": "str"},
+                "api_version" : {"required": False, "choices": [ '1.0', '2.0', '3.0', '4.0', '5.0' ], type: "str", "default": '2.0'},
                 "key" : {"required": False, "type": "str"},
                 "snap_mirror_policy_key" : {"required": False, "type": "str"},
                 "keep" : {"required": False, "type": "str"},
@@ -211,6 +212,7 @@ def main():
         global api_port
         global api_user_name
         global api_user_password
+        global api_version
 
         global lun_key
         global nfs_share_key
@@ -219,6 +221,7 @@ def main():
         api_port                = module.params["port"]
         api_user_name           = module.params["user"]
         api_user_password       = module.params["password"]
+        api_version             = module.params["api_version"]
 
         # Properties details
         global key

--- a/Modules/SnapshotModule.py
+++ b/Modules/SnapshotModule.py
@@ -27,7 +27,7 @@ warnings.filterwarnings("ignore")
 
 
 def get():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
 
     flag=0
 
@@ -118,7 +118,7 @@ def get():
     return json_response
 
 def post():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="snapshots"
 
     payload={}
@@ -154,7 +154,7 @@ def post():
     return json_response
 
 def put():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="snapshots/"
 
     payload={}
@@ -193,7 +193,7 @@ def put():
         return "Provide the object key"
 
 def delete():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="snapshots/"
 
     if key != None:
@@ -233,6 +233,7 @@ def main():
                 "port" : {"required": True, "type": "str"},
                 "user" : {"required": True, "type": "str"},
                 "password" : {"required": True, "type": "str"},
+                "api_version" : {"required": False, "choices": [ '1.0', '2.0', '3.0', '4.0', '5.0' ], type: "str", "default": '2.0'},
                 "key" : {"required": False, "type": "str"},
                 "name" : {"required": False, "type": "str"},
                 "snapmirror_label" : {"required": False, "type": "str"},
@@ -255,6 +256,7 @@ def main():
         global api_port
         global api_user_name
         global api_user_password
+        global api_version
 
         global lun_key
         global nfs_share_key
@@ -263,6 +265,7 @@ def main():
         api_port                = module.params["port"]
         api_user_name           = module.params["user"]
         api_user_password       = module.params["password"]
+        api_version             = module.params["api_version"]
 
         # Properties details
         global key

--- a/Modules/SnapshotPolicyModule.py
+++ b/Modules/SnapshotPolicyModule.py
@@ -27,7 +27,7 @@ warnings.filterwarnings("ignore")
 
 
 def get():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
 
     flag=0
 
@@ -106,7 +106,7 @@ def get():
     return json_response
 
 def post():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="snapshot-policies"
 
     payload={}
@@ -138,7 +138,7 @@ def post():
     return json_response
 
 def put():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="snapshot-policies/"
 
     payload={}
@@ -173,7 +173,7 @@ def put():
         return "Provide the object key"
 
 def delete():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="snapshot-policies/"
 
     if key != None:
@@ -213,6 +213,7 @@ def main():
                 "port" : {"required": True, "type": "str"},
                 "user" : {"required": True, "type": "str"},
                 "password" : {"required": True, "type": "str"},
+                "api_version" : {"required": False, "choices": [ '1.0', '2.0', '3.0', '4.0', '5.0' ], type: "str", "default": '2.0'},
                 "key" : {"required": False, "type": "str"},
                 "name" : {"required": False, "type": "str"},
                 "storage_vm_key" : {"required": False, "type": "str"},
@@ -233,6 +234,7 @@ def main():
         global api_port
         global api_user_name
         global api_user_password
+        global api_version
 
         global lun_key
         global nfs_share_key
@@ -241,6 +243,7 @@ def main():
         api_port                = module.params["port"]
         api_user_name           = module.params["user"]
         api_user_password       = module.params["password"]
+        api_version             = module.params["api_version"]
 
         # Properties details
         global key

--- a/Modules/SnapshotPolicyScheduleModule.py
+++ b/Modules/SnapshotPolicyScheduleModule.py
@@ -27,7 +27,7 @@ warnings.filterwarnings("ignore")
 
 
 def get():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
 
     flag=0
 
@@ -94,7 +94,7 @@ def get():
     return json_response
 
 def post():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="snapshot-policy-schedules"
 
     payload={}
@@ -122,7 +122,7 @@ def post():
     return json_response
 
 def put():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="snapshot-policy-schedules/"
 
     payload={}
@@ -153,7 +153,7 @@ def put():
         return "Provide the object key"
 
 def delete():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="snapshot-policy-schedules/"
 
     if key != None:
@@ -193,6 +193,7 @@ def main():
                 "port" : {"required": True, "type": "str"},
                 "user" : {"required": True, "type": "str"},
                 "password" : {"required": True, "type": "str"},
+                "api_version" : {"required": False, "choices": [ '1.0', '2.0', '3.0', '4.0', '5.0' ], type: "str", "default": '2.0'},
                 "key" : {"required": False, "type": "str"},
                 "snapshot_policy_key" : {"required": False, "type": "str"},
                 "job_schedule_key" : {"required": False, "type": "str"},
@@ -211,6 +212,7 @@ def main():
         global api_port
         global api_user_name
         global api_user_password
+        global api_version
 
         global lun_key
         global nfs_share_key
@@ -219,6 +221,7 @@ def main():
         api_port                = module.params["port"]
         api_user_name           = module.params["user"]
         api_user_password       = module.params["password"]
+        api_version             = module.params["api_version"]
 
         # Properties details
         global key

--- a/Modules/StoragePoolAggregateRelationshipModule.py
+++ b/Modules/StoragePoolAggregateRelationshipModule.py
@@ -27,7 +27,7 @@ warnings.filterwarnings("ignore")
 
 
 def get():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
 
     flag=0
 
@@ -94,7 +94,7 @@ def get():
     return json_response
 
 def post():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="storage-pool-aggregate-relationships"
 
     payload={}
@@ -122,7 +122,7 @@ def post():
     return json_response
 
 def put():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="storage-pool-aggregate-relationships/"
 
     payload={}
@@ -153,7 +153,7 @@ def put():
         return "Provide the object key"
 
 def delete():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="storage-pool-aggregate-relationships/"
 
     if key != None:
@@ -193,6 +193,7 @@ def main():
                 "port" : {"required": True, "type": "str"},
                 "user" : {"required": True, "type": "str"},
                 "password" : {"required": True, "type": "str"},
+                "api_version" : {"required": False, "choices": [ '1.0', '2.0', '3.0', '4.0', '5.0' ], type: "str", "default": '2.0'},
                 "key" : {"required": False, "type": "str"},
                 "storage_pool_key" : {"required": False, "type": "str"},
                 "aggregate_key" : {"required": False, "type": "str"},
@@ -211,6 +212,7 @@ def main():
         global api_port
         global api_user_name
         global api_user_password
+        global api_version
 
         global lun_key
         global nfs_share_key
@@ -219,6 +221,7 @@ def main():
         api_port                = module.params["port"]
         api_user_name           = module.params["user"]
         api_user_password       = module.params["password"]
+        api_version             = module.params["api_version"]
 
         # Properties details
         global key

--- a/Modules/StoragePoolModule.py
+++ b/Modules/StoragePoolModule.py
@@ -27,7 +27,7 @@ warnings.filterwarnings("ignore")
 
 
 def get():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
 
     flag=0
 
@@ -112,7 +112,7 @@ def get():
     return json_response
 
 def post():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="storage-pools"
 
     payload={}
@@ -146,7 +146,7 @@ def post():
     return json_response
 
 def put():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="storage-pools/"
 
     payload={}
@@ -183,7 +183,7 @@ def put():
         return "Provide the object key"
 
 def delete():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="storage-pools/"
 
     if key != None:
@@ -223,6 +223,7 @@ def main():
                 "port" : {"required": True, "type": "str"},
                 "user" : {"required": True, "type": "str"},
                 "password" : {"required": True, "type": "str"},
+                "api_version" : {"required": False, "choices": [ '1.0', '2.0', '3.0', '4.0', '5.0' ], type: "str", "default": '2.0'},
                 "key" : {"required": False, "type": "str"},
                 "cluster_key" : {"required": False, "type": "str"},
                 "name" : {"required": False, "type": "str"},
@@ -244,6 +245,7 @@ def main():
         global api_port
         global api_user_name
         global api_user_password
+        global api_version
 
         global lun_key
         global nfs_share_key
@@ -252,6 +254,7 @@ def main():
         api_port                = module.params["port"]
         api_user_name           = module.params["user"]
         api_user_password       = module.params["password"]
+        api_version             = module.params["api_version"]
 
         # Properties details
         global key

--- a/Modules/StorageShelfModule.py
+++ b/Modules/StorageShelfModule.py
@@ -27,7 +27,7 @@ warnings.filterwarnings("ignore")
 
 
 def get():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
 
     flag=0
 
@@ -100,7 +100,7 @@ def get():
     return json_response
 
 def post():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="storage-shelfs"
 
     payload={}
@@ -130,7 +130,7 @@ def post():
     return json_response
 
 def put():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="storage-shelfs/"
 
     payload={}
@@ -163,7 +163,7 @@ def put():
         return "Provide the object key"
 
 def delete():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="storage-shelfs/"
 
     if key != None:
@@ -203,6 +203,7 @@ def main():
                 "port" : {"required": True, "type": "str"},
                 "user" : {"required": True, "type": "str"},
                 "password" : {"required": True, "type": "str"},
+                "api_version" : {"required": False, "choices": [ '1.0', '2.0', '3.0', '4.0', '5.0' ], type: "str", "default": '2.0'},
                 "key" : {"required": False, "type": "str"},
                 "shelf_model" : {"required": False, "type": "str"},
                 "shelf" : {"required": False, "type": "str"},
@@ -222,6 +223,7 @@ def main():
         global api_port
         global api_user_name
         global api_user_password
+        global api_version
 
         global lun_key
         global nfs_share_key
@@ -230,6 +232,7 @@ def main():
         api_port                = module.params["port"]
         api_user_name           = module.params["user"]
         api_user_password       = module.params["password"]
+        api_version             = module.params["api_version"]
 
         # Properties details
         global key

--- a/Modules/StorageVMAggregateRelationshipModule.py
+++ b/Modules/StorageVMAggregateRelationshipModule.py
@@ -27,7 +27,7 @@ warnings.filterwarnings("ignore")
 
 
 def get():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
 
     flag=0
 
@@ -76,7 +76,7 @@ def get():
     return json_response
 
 def post():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="storage-vm-aggregate-relationships"
 
     payload={}
@@ -98,7 +98,7 @@ def post():
     return json_response
 
 def put():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="storage-vm-aggregate-relationships/"
 
     payload={}
@@ -123,7 +123,7 @@ def put():
         return "Provide the object key"
 
 def delete():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="storage-vm-aggregate-relationships/"
 
     if key != None:
@@ -163,6 +163,7 @@ def main():
                 "port" : {"required": True, "type": "str"},
                 "user" : {"required": True, "type": "str"},
                 "password" : {"required": True, "type": "str"},
+                "api_version" : {"required": False, "choices": [ '1.0', '2.0', '3.0', '4.0', '5.0' ], type: "str", "default": '2.0'},
                 "key" : {"required": False, "type": "str"},
                 "storage_vm_key" : {"required": False, "type": "str"},
                 "aggregate_key" : {"required": False, "type": "str"},
@@ -178,6 +179,7 @@ def main():
         global api_port
         global api_user_name
         global api_user_password
+        global api_version
 
         global lun_key
         global nfs_share_key
@@ -186,6 +188,7 @@ def main():
         api_port                = module.params["port"]
         api_user_name           = module.params["user"]
         api_user_password       = module.params["password"]
+        api_version             = module.params["api_version"]
 
         # Properties details
         global key

--- a/Modules/StorageVMModule.py
+++ b/Modules/StorageVMModule.py
@@ -27,7 +27,7 @@ warnings.filterwarnings("ignore")
 
 
 def get():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
 
     flag=0
 
@@ -388,7 +388,7 @@ def get():
     return json_response
 
 def post():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="storage-vms"
 
     payload={}
@@ -514,7 +514,7 @@ def post():
     return json_response
 
 def put():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="storage-vms/"
 
     payload={}
@@ -643,7 +643,7 @@ def put():
         return "Provide the object key"
 
 def delete():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="storage-vms/"
 
     if key != None:
@@ -683,6 +683,7 @@ def main():
                 "port" : {"required": True, "type": "str"},
                 "user" : {"required": True, "type": "str"},
                 "password" : {"required": True, "type": "str"},
+                "api_version" : {"required": False, "choices": [ '1.0', '2.0', '3.0', '4.0', '5.0' ], type: "str", "default": '2.0'},
                 "key" : {"required": False, "type": "str"},
                 "name" : {"required": False, "type": "str"},
                 "cluster_key" : {"required": False, "type": "str"},
@@ -750,6 +751,7 @@ def main():
         global api_port
         global api_user_name
         global api_user_password
+        global api_version
 
         global lun_key
         global nfs_share_key
@@ -758,6 +760,7 @@ def main():
         api_port                = module.params["port"]
         api_user_name           = module.params["user"]
         api_user_password       = module.params["password"]
+        api_version             = module.params["api_version"]
 
         # Properties details
         global key

--- a/Modules/StorageVMPeerModule.py
+++ b/Modules/StorageVMPeerModule.py
@@ -27,7 +27,7 @@ warnings.filterwarnings("ignore")
 
 
 def get():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
 
     flag=0
 
@@ -100,7 +100,7 @@ def get():
     return json_response
 
 def post():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="storage-vm-peers"
 
     payload={}
@@ -130,7 +130,7 @@ def post():
     return json_response
 
 def put():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="storage-vm-peers/"
 
     payload={}
@@ -163,7 +163,7 @@ def put():
         return "Provide the object key"
 
 def delete():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="storage-vm-peers/"
 
     if key != None:
@@ -203,6 +203,7 @@ def main():
                 "port" : {"required": True, "type": "str"},
                 "user" : {"required": True, "type": "str"},
                 "password" : {"required": True, "type": "str"},
+                "api_version" : {"required": False, "choices": [ '1.0', '2.0', '3.0', '4.0', '5.0' ], type: "str", "default": '2.0'},
                 "key" : {"required": False, "type": "str"},
                 "storage_vm_key" : {"required": False, "type": "str"},
                 "peer_storage_vm_key" : {"required": False, "type": "str"},
@@ -222,6 +223,7 @@ def main():
         global api_port
         global api_user_name
         global api_user_password
+        global api_version
 
         global lun_key
         global nfs_share_key
@@ -230,6 +232,7 @@ def main():
         api_port                = module.params["port"]
         api_user_name           = module.params["user"]
         api_user_password       = module.params["password"]
+        api_version             = module.params["api_version"]
 
         # Properties details
         global key

--- a/Modules/VolumeModule.py
+++ b/Modules/VolumeModule.py
@@ -27,7 +27,7 @@ warnings.filterwarnings("ignore")
 
 
 def get():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
 
     flag=0
 
@@ -59,6 +59,12 @@ def get():
             flag=1
         else:
             url_path+="&aggregate_key="+aggregate_key
+    if aggregate_keys != None:
+        if flag is 0:
+            url_path+="?aggregate_keys="+aggregate_keys
+            flag=1
+        else:
+            url_path+="&aggregate_keys="+aggregate_keys
     if export_policy_key != None:
         if flag is 0:
             url_path+="?export_policy_key="+export_policy_key
@@ -628,7 +634,7 @@ def get():
     return json_response
 
 def post():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="volumes"
 
     payload={}
@@ -640,6 +646,8 @@ def post():
         payload['storage_vm_key']=storage_vm_key
     if (aggregate_key != None) & (aggregate_key != key):
         payload['aggregate_key']=aggregate_key
+    if (aggregate_keys != None) & (aggregate_keys != key):
+        payload['aggregate_keys']=aggregate_keys
     if (export_policy_key != None) & (export_policy_key != key):
         payload['export_policy_key']=export_policy_key
     if (clone_parent_key != None) & (clone_parent_key != key):
@@ -834,7 +842,7 @@ def post():
     return json_response
 
 def put():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="volumes/"
 
     payload={}
@@ -846,6 +854,8 @@ def put():
         payload['storage_vm_key']=storage_vm_key
     if (aggregate_key != None) & (aggregate_key != key):
         payload['aggregate_key']=aggregate_key
+    if (aggregate_keys != None) & (aggregate_keys != key):
+        payload['aggregate_keys']=aggregate_keys
     if (export_policy_key != None) & (export_policy_key != key):
         payload['export_policy_key']=export_policy_key
     if (clone_parent_key != None) & (clone_parent_key != key):
@@ -1043,7 +1053,7 @@ def put():
         return "Provide the object key"
 
 def delete():
-    url_path        = "/api/2.0/ontap/"
+    url_path        = "/api/" + api_version + "/ontap/"
     url_path+="volumes/"
 
     if key != None:
@@ -1083,10 +1093,12 @@ def main():
                 "port" : {"required": True, "type": "str"},
                 "user" : {"required": True, "type": "str"},
                 "password" : {"required": True, "type": "str"},
+                "api_version" : {"required": False, "choices": [ '1.0', '2.0', '3.0', '4.0', '5.0' ], type: "str", "default": '2.0'},
                 "key" : {"required": False, "type": "str"},
                 "name" : {"required": False, "type": "str"},
                 "storage_vm_key" : {"required": False, "type": "str"},
                 "aggregate_key" : {"required": False, "type": "str"},
+                "aggregate_keys" : {"required": False, "type": "list"},
                 "export_policy_key" : {"required": False, "type": "str"},
                 "clone_parent_key" : {"required": False, "type": "str"},
                 "flex_cache_origin_key" : {"required": False, "type": "str"},
@@ -1190,6 +1202,7 @@ def main():
         global api_port
         global api_user_name
         global api_user_password
+        global api_version
 
         global lun_key
         global nfs_share_key
@@ -1198,6 +1211,7 @@ def main():
         api_port                = module.params["port"]
         api_user_name           = module.params["user"]
         api_user_password       = module.params["password"]
+        api_version             = module.params["api_version"]
 
         # Properties details
         global key
@@ -1208,6 +1222,8 @@ def main():
         storage_vm_key = module.params["storage_vm_key"]
         global aggregate_key
         aggregate_key = module.params["aggregate_key"]
+        global aggregate_keys
+        aggregate_keys = module.params["aggregate_keys"]
         global export_policy_key
         export_policy_key = module.params["export_policy_key"]
         global clone_parent_key


### PR DESCRIPTION
* Made the API version selectable for the end-user though it defaults
to version 2.0 so as not to make any changes in the way everything works.
* Added the parameter "aggregate_keys" (plural = list) to the VolumeModule
which is necessary if we wish to use API version 4.0+ instead of
aggregate_key
* Fixed the url_path of JobScheduleModule to point to job-schedules
instead of jobs